### PR TITLE
Update pcp for the workload metrics, so information appears as expected.

### DIFF
--- a/specjbb/openmetrics_specjbb_reset.txt
+++ b/specjbb/openmetrics_specjbb_reset.txt
@@ -7,3 +7,4 @@ latency NaN
 JVMs NaN
 Warehouse NaN
 BOPs NaN
+Numa_bound NaN

--- a/specjbb/openmetrics_specjbb_reset.txt
+++ b/specjbb/openmetrics_specjbb_reset.txt
@@ -1,0 +1,8 @@
+iteration 0
+running 0
+numthreads 0
+runtime NaN
+throughput NaN
+latency NaN
+Warehouse NaN
+BOPs NaN

--- a/specjbb/openmetrics_specjbb_reset.txt
+++ b/specjbb/openmetrics_specjbb_reset.txt
@@ -4,5 +4,6 @@ numthreads 0
 runtime NaN
 throughput NaN
 latency NaN
+JVMs NaN
 Warehouse NaN
 BOPs NaN

--- a/specjbb/specjbb_run
+++ b/specjbb/specjbb_run
@@ -24,6 +24,7 @@
 #
 # Defined options
 #
+act_jvms=0
 java_version=21
 RESULTSDIR_TOP=""
 rtc=0
@@ -144,13 +145,14 @@ present_wh_results()
 		#
 		if [ $last_wh -ne $wh ]; then
 			if [[ $to_use_pcp -eq 1 ]]; then
-				result2pcp Warehouse ${total_wh}
-				result2pcp BOPs ${total_bops}
+				results2pcp_add_value "Warehouse:${total_wh}"
+				results2pcp_add_value "BOPs:${total_bops}"
+				results2pcp_add_value "JVMs:${act_jvms}"
+				results2pcp_add_value_commit
 				#
 				# To prevent WH confusion, reset. Do not reset iterations
 				#
-				result2pcp Warehouse 0
-				result2pcp BOPs 0
+				reset_pcp_om
 			fi
 			echo $total_wh:$total_bops >> $2
 			total_bops=$val
@@ -169,13 +171,14 @@ present_wh_results()
 	#
 	echo $total_wh:$total_bops >> $2
 	if [[ $to_use_pcp -eq 1 ]]; then
-		result2pcp Warehouse ${total_wh}
-		result2pcp BOPs ${total_bops}
+		results2pcp_add_value "Warehouse:${total_wh}"
+		results2pcp_add_value "BOPs:${total_bops}"
+		results2pcp_add_value "JVMs:${act_jvms}"
+		results2pcp_add_value_commit
 		#
 		# To prevent WH confusion, reset. Do not reset iterations
 		#
-		result2pcp Warehouse 0
-		result2pcp BOPs 0
+		reset_pcp_om
 	fi
 }
 

--- a/specjbb/specjbb_run
+++ b/specjbb/specjbb_run
@@ -477,26 +477,10 @@ run_specjbb()
 	# Arrays are 0 based
 	let nr_jvms="$nr_jvms-1"
 
-	if [[ $to_use_pcp -eq 1 ]]; then
-		source $TOOLS_BIN/pcp/pcp_commands.inc
-		setup_pcp
-		pcp_cfg=$TOOLS_BIN/pcp/default.cfg
-		#
-		# Set the pcp file and include the number of jvm nodes doing.
-		#
-		pcp_out=specjbb_jvms_${node_jvms}
-		#
-		# Only set this once.  We want all the pcp files in one directory.
-		#
-		if [[ $pdir == "" ]]; then
-			pdir=/tmp/pcp_`date "+%Y.%m.%d-%H.%M.%S"`
-		fi
-		start_pcp ${pdir}/ $pcp_out $pcp_cfg
-	fi
 
 	for iterations  in 1 `seq 2 1 $to_times_to_run`; do
 		pindex=0
-		if [[ $pcp -eq 1 ]]; then
+		if [[ $to_use_pcp -eq 1 ]]; then
 			start_pcp_subset
 		fi
 
@@ -527,14 +511,10 @@ run_specjbb()
 		timestamp=`date | sed "s/ /_/g"`
 		mv $run_dir/results_specjbb  ${RESULTSDIR}/results_${test_name}_${timestamp}
 		process_specjbb_data
-		if [[ $pcp -eq 1 ]]; then
+		if [[ $to_use_pcp -eq 1 ]]; then
 			stop_pcp_subset
 		fi
 	done
-	if [[ $pcp -eq 1 ]]; then
-		stop_pcp
-		shutdown_pcp
-	fi
 }
 
 usage()
@@ -792,6 +772,22 @@ fi
 #
 # Iterate over the nodes
 #
+if [[ $to_use_pcp -eq 1 ]]; then
+	source $TOOLS_BIN/pcp/pcp_commands.inc
+	setup_pcp
+	pcp_cfg=$TOOLS_BIN/pcp/default.cfg
+	#
+	# Set the pcp file and include the number of jvm nodes doing.
+	#
+	pcp_out=specjbb_jvms_${node_jvms}
+	#
+	# Only set this once.  We want all the pcp files in one directory.
+	#
+	if [[ $pdir == "" ]]; then
+		pdir=/tmp/pcp_`date "+%Y.%m.%d-%H.%M.%S"`
+	fi
+	start_pcp ${pdir}/ $pcp_out $pcp_cfg
+fi
 
 for entry in $nodes; do
 	#
@@ -813,7 +809,6 @@ for entry in $nodes; do
 	if [[ $node_pinning == "y" ]]; then
 		obtain_nodes
 	fi
-
 
 	run_specjbb
 done

--- a/specjbb/specjbb_run
+++ b/specjbb/specjbb_run
@@ -145,6 +145,11 @@ present_wh_results()
 				results2pcp_add_value "Warehouse:${total_wh}"
 				results2pcp_add_value "BOPs:${total_bops}"
 				results2pcp_add_value "JVMs:${jvms}"
+				if [[ $node_pinning == "y" ]]; then
+					results2pcp_add_value "Numa_bound:1"
+				else
+					results2pcp_add_value "Numa_bound:0"
+				fi
 				results2pcp_add_value_commit
 				#
 				# To prevent WH confusion, reset. Do not reset iterations
@@ -174,6 +179,11 @@ present_wh_results()
 		results2pcp_add_value "BOPs:${total_bops}"
 		results2pcp_add_value "JVMs:${act_jvms}"
 		results2pcp_add_value_commit
+		if [[ $node_pinning == "y" ]]; then
+			results2pcp_add_value "Numa_bound:1"
+		else
+			results2pcp_add_value "Numa_bound:0"
+		fi
 		#
 		# To prevent WH confusion, reset. Do not reset iterations
 		#

--- a/specjbb/specjbb_run
+++ b/specjbb/specjbb_run
@@ -47,6 +47,7 @@ java_exec="/bin/java"
 test_status="Ran"
 start_warehouse=0
 increment_warehouse=0
+pdir=""
 
 tools_git=https://github.com/redhat-performance/test_tools-wrappers
 
@@ -142,6 +143,15 @@ present_wh_results()
 		# and reset the values.
 		#
 		if [ $last_wh -ne $wh ]; then
+			if [[ $to_use_pcp -eq 1 ]]; then
+				result2pcp Warehouse ${total_wh}
+				result2pcp BOPs ${total_bops}
+				#
+				# To prevent WH confusion, reset. Do not reset iterations
+				#
+				result2pcp Warehouse 0
+				result2pcp BOPs 0
+			fi
 			echo $total_wh:$total_bops >> $2
 			total_bops=$val
 			total_wh=$wh
@@ -158,6 +168,15 @@ present_wh_results()
 	# Do not forget the last Warehouse count.
 	#
 	echo $total_wh:$total_bops >> $2
+	if [[ $to_use_pcp -eq 1 ]]; then
+		result2pcp Warehouse ${total_wh}
+		result2pcp BOPs ${total_bops}
+		#
+		# To prevent WH confusion, reset. Do not reset iterations
+		#
+		result2pcp Warehouse 0
+		result2pcp BOPs 0
+	fi
 }
 
 #
@@ -424,13 +443,6 @@ execute_specjbb()
 		fi
 	done
 
-	if [[ $to_use_pcp -eq 1 ]]; then
-		echo "Send result to PCP archive"
-		out="${test_to_run}_pcp"
-		result2pcp nr_jvms_${nr_jvms}  ${out}
-		stop_pcp_subset
-	fi
-
 	if [[ $node_jvms -gt 1 ]]; then
 		kill $controller_pid > /dev/null 2>&1
 		wait $controller_pid
@@ -459,11 +471,32 @@ run_specjbb()
 	# Prepare things for execution.
 	#
 	file=`/$to_home_root/$to_user/tools_bin/get_params_file -d /$to_home_root/$to_user -c ${to_sysname} -t ${test_name}`
-
 	# Arrays are 0 based
 	let nr_jvms="$nr_jvms-1"
+
+	if [[ $to_use_pcp -eq 1 ]]; then
+		source $TOOLS_BIN/pcp/pcp_commands.inc
+		setup_pcp
+		pcp_cfg=$TOOLS_BIN/pcp/default.cfg
+		#
+		# Set the pcp file and include the number of jvm nodes doing.
+		#
+		pcp_out=specjbb_jvms_${node_jvms}
+		#
+		# Only set this once.  We want all the pcp files in one directory.
+		#
+		if [[ $pdir == "" ]]; then
+			pdir=/tmp/pcp_`date "+%Y.%m.%d-%H.%M.%S"`
+		fi
+		start_pcp ${pdir}/ $pcp_out $pcp_cfg
+	fi
+
 	for iterations  in 1 `seq 2 1 $to_times_to_run`; do
 		pindex=0
+		if [[ $pcp -eq 1 ]]; then
+			start_pcp_subset
+		fi
+
 		if test -f "$file"; then
 			while IFS= read -r specjbb_opts
 			do
@@ -472,26 +505,33 @@ run_specjbb()
 		else
 			execute_specjbb $specjbb_opts
 		fi
-	done
 
-#
-# We need to process the data
-#
-	pushd /tmp > /dev/null
-	if [[ $RESULTSDIR_TOP == "" ]]; then
-		RESULTSDIR_TOP=results_${test_name}_${tuned_setting}_$(date "+%Y.%m.%d-%H.%M.%S")
+		#
+		# We need to process the data
+		#
+		pushd /tmp > /dev/null
+		if [[ $RESULTSDIR_TOP == "" ]]; then
+			RESULTSDIR_TOP=results_${test_name}_${tuned_setting}_$(date "+%Y.%m.%d-%H.%M.%S")
+		fi
+		RESULTSDIR=${RESULTSDIR_TOP}/results_${test_name}_${to_tuned_setting}_${node_jvms}_results
+		# We do not want any old data.
+		#
+		mkdir -p ${RESULTSDIR}
+		if [[ -d results_${test_name}_${to_tuned_setting} ]]; then
+			mv results_${test_name}_${to_tuned_setting} ${RESULTSDIR}
+		fi
+		echo $test_status > ${RESULTSDIR}/test_results_report
+		timestamp=`date | sed "s/ /_/g"`
+		mv $run_dir/results_specjbb  ${RESULTSDIR}/results_${test_name}_${timestamp}
+		process_specjbb_data
+		if [[ $pcp -eq 1 ]]; then
+			stop_pcp_subset
+		fi
+	done
+	if [[ $pcp -eq 1 ]]; then
+		stop_pcp
+		shutdown_pcp
 	fi
-	RESULTSDIR=${RESULTSDIR_TOP}/results_${test_name}_${to_tuned_setting}_${node_jvms}_results
-	# We do not want any old data.
-	#
-	mkdir -p ${RESULTSDIR}
-	if [[ -d results_${test_name}_${to_tuned_setting} ]]; then
-		mv results_${test_name}_${to_tuned_setting} ${RESULTSDIR}
-	fi
-	echo $test_status > ${RESULTSDIR}/test_results_report
-	timestamp=`date | sed "s/ /_/g"`
-	mv $run_dir/results_specjbb  ${RESULTSDIR}/results_${test_name}_${timestamp}
-	process_specjbb_data
 }
 
 usage()
@@ -749,14 +789,6 @@ fi
 #
 # Iterate over the nodes
 #
-if [[ $to_use_pcp -eq 1 ]]; then
-	source $TOOLS_BIN/pcp/pcp_commands.inc
-	setup_pcp
-	pcp_cfg=$TOOLS_BIN/pcp/default.cfg
-	pdir=/tmp/pcp_`date "+%Y.%m.%d-%H.%M.%S"`
-	echo "Start PCP"
-	start_pcp ${pdir}/ specjbb $pcp_cfg
-fi
 
 for entry in $nodes; do
 	#

--- a/specjbb/specjbb_run
+++ b/specjbb/specjbb_run
@@ -110,19 +110,16 @@ error_out()
 }
 
 #
-# results_specjbb.csv header
-#
-process_header()
-{
-	echo "Warehouses:Bops" >> $1
-}
-
-#
 # For runs with multiple JVMs, we need to sum everything up.  Note,
 # this includes the WH count, as each JVM is running (Total WH)/# JVMs.
 #
 present_wh_results()
 {
+	in_file=${1}
+	csv_file=${2}
+	jvms=${3}
+	start_time=${4}
+	end_time=${5}
 	last_wh=0
 	total_wh=0
 	total_bops=0
@@ -147,14 +144,15 @@ present_wh_results()
 			if [[ $to_use_pcp -eq 1 ]]; then
 				results2pcp_add_value "Warehouse:${total_wh}"
 				results2pcp_add_value "BOPs:${total_bops}"
-				results2pcp_add_value "JVMs:${act_jvms}"
+				results2pcp_add_value "JVMs:${jvms}"
 				results2pcp_add_value_commit
 				#
 				# To prevent WH confusion, reset. Do not reset iterations
 				#
 				reset_pcp_om
 			fi
-			echo $total_wh:$total_bops >> $2
+			data_string=$(build_data_string "$total_wh" "$total_bops" "$jvms" "${start_time}" "${end_time}")
+			echo $data_string >> $csv_file
 			total_bops=$val
 			total_wh=$wh
 			last_wh=$wh
@@ -165,11 +163,12 @@ present_wh_results()
 		#
 		let "total_wh=$total_wh+$wh"
 		let "total_bops=$total_bops+$val"
-	done < "$1"
+	done < "${in_file}"
 	#
 	# Do not forget the last Warehouse count.
 	#
-	echo $total_wh:$total_bops >> $2
+	data_string=$(build_data_string "$total_wh" "$total_bops" "$jvms" "${start_time}" "${end_time}")
+	echo $data_string >> $csv_file
 	if [[ $to_use_pcp -eq 1 ]]; then
 		results2pcp_add_value "Warehouse:${total_wh}"
 		results2pcp_add_value "BOPs:${total_bops}"
@@ -187,6 +186,8 @@ present_wh_results()
 #
 process_specjbb_data()
 {
+	start_time=${1}
+	slart_time=${2}
 	total_data=$(mktemp /tmp/specjbb_data.XXXXXX)
 	#
 	# Locate the last created specjbb results
@@ -202,11 +203,7 @@ process_specjbb_data()
 		pushd $lvl2 > /tmp/null
 		csv_file=`pwd`/results_${test_name}.csv
 		if [ ! -f $csv_file ]; then
-			$TOOLS_BIN/test_header_info --front_matter --results_file $csv_file --host $to_configuration --sys_type $to_sys_type --tuned $to_tuned_setting --results_version $version --test_name $test_name
-			#
-			# Add test meta for the total number of JVMs
-			#
-			$TOOLS_BIN/test_header_info --results_file $csv_file --meta_output "Number of jvms: $node_jvms"
+			$TOOLS_BIN/test_header_info --front_matter --results_file $csv_file --host $to_configuration --sys_type $to_sys_type --tuned $to_tuned_setting --results_version $version --test_name $test_name --field_header "Warehouses,Bops,Numb_JVMs"
 		fi
 		for dir_work in `ls -d SPEC*`; do
 			pushd $dir_work > /dev/null
@@ -227,13 +224,6 @@ process_specjbb_data()
 			# Afterwards we will organize the data.
 			#
 			for file_in in `ls SPEC*txt`; do
-				#
-				# If first time through, we need to provide the header.
-				#
-				if [[ $processed -eq 0 ]]; then
-					process_header $csv_file
-					processed=1
-				fi
 				wh_found=0
 				cat $file_in | sed "s/[*]/ /g" > ${file_in}.out
 				while IFS= read -r data_in
@@ -262,7 +252,7 @@ process_specjbb_data()
 				# to sum the run up.
 				#
 				sort -n $total_data > ${total_data}_sorted
-				present_wh_results ${total_data}_sorted $csv_file
+				present_wh_results ${total_data}_sorted $csv_file $node_jvms ${start_time} ${end_time}
 				rm ${total_data}*
 				popd > /dev/null
 			fi
@@ -490,7 +480,9 @@ run_specjbb()
 				execute_specjbb $specjbb_opts
 			done < "$file"
 		else
+			start_time=$(retrieve_time_stamp)
 			execute_specjbb $specjbb_opts
+			end_time=$(retrieve_time_stamp)
 		fi
 
 		#
@@ -510,7 +502,7 @@ run_specjbb()
 		echo $test_status > ${RESULTSDIR}/test_results_report
 		timestamp=`date | sed "s/ /_/g"`
 		mv $run_dir/results_specjbb  ${RESULTSDIR}/results_${test_name}_${timestamp}
-		process_specjbb_data
+		process_specjbb_data $start_time $end_time 
 		if [[ $to_use_pcp -eq 1 ]]; then
 			stop_pcp_subset
 		fi


### PR DESCRIPTION
# Description
Fixes the pcp output so
1) Data is actually present as expected
2) Handles numa nodes.
3) Convert csv file to use ,'s
4) Add timestamps (phase 1.  follow on work to deal with multiple iterations and looking at running 1 wh at a time for timestamp purpose

# Before/After Comparison
Before:
Send result to PCP archive
Logging results nr_jvms_0 _pcp
Unexpected metric logged. Check for a typo.
Stopping PCP subset
  adding: results_specjbb_virtual-guest.tar (deflated 86%)

pmrep -p -a  specjbb.0 openmetrics.workloads > foo

Does not show the desired workload data.


After
pmrep -p -a  specjbb_jvms_0.0 openmetrics.workload
(partial output)
          o.w.iteration  o.w.running  o.w.numthreads  o.w.runtime  o.w.throughput  o.w.latency  o.w.Warehouse  o.w.BOPs  o.w.JVMs

16:06:18          0.000        1.000           0.000          NaN             NaN          NaN          2.000  215137.0     1.000
16:06:19          0.000        1.000           0.000          NaN             NaN          NaN          2.000  215137.0     1.000
16:06:20          0.000        0.000           0.000          NaN             NaN          NaN            NaN       NaN       NaN
16:06:21          0.000        0.000           0.000          NaN             NaN          NaN            NaN       NaN       NaN
16:06:22          0.000        0.000           0.000          NaN             NaN          NaN          4.000  269278.0     1.000
16:06:23          0.000        0.000           0.000          NaN             NaN          NaN          4.000  269278.0     1.000
16:06:24          0.000        0.000           0.000          NaN             NaN          NaN            NaN       NaN       NaN
16:06:25          0.000        0.000           0.000          NaN             NaN          NaN            NaN       NaN       NaN
16:06:26          0.000        0.000           0.000          NaN             NaN          NaN          6.000  266119.0     1.000
16:06:27          0.000        0.000           0.000          NaN             NaN          NaN          6.000  266119.0     1.000
16:06:28          0.000        0.000           0.000          NaN             NaN          NaN            NaN       NaN       NaN
16:06:29          0.000        0.000           0.000          NaN             NaN          NaN            NaN       NaN       NaN
16:06:30          0.000        0.000           0.000          NaN             NaN          NaN            NaN       NaN       NaN
16:06:31          0.000        0.000           0.000          NaN             NaN          NaN          8.000  261159.0     1.000
16:06:32          0.000        0.000           0.000          NaN             NaN          NaN          8.000  261159.0     1.000


# Clerical Stuff
This closes #48 


Relates to JIRA: RPOPC-760

# Test information

Command executed: 
/home/ec2-user/workloads/specjbb-wrapper/specjbb/specjbb_run --run_user ec2-user --home_parent /home --iterations 1 --tuned_setting tuned_none_sys_file_ --host_config "m5a.24xlarge" --sysname "m5a.24xlarge" --sys_type aws  --use_pcp  --java_version 21 --debug


===============================
csv file
===============================
Single jvm
Warehouses,Bops,Numb_JVMs,Start_Date,End_Date
24,847245,1,2026-01-28T14:12:35Z,2026-01-28T14:21:03Z
48,1158553,1,2026-01-28T14:12:35Z,2026-01-28T14:21:03Z
72,1065174,1,2026-01-28T14:12:35Z,2026-01-28T14:21:03Z
96,961328,1,2026-01-28T14:12:35Z,2026-01-28T14:21:03Z
120,918485,1,2026-01-28T14:12:35Z,2026-01-28T14:21:03Z
144,872202,1,2026-01-28T14:12:35Z,2026-01-28T14:21:03Z
168,808530,1,2026-01-28T14:12:35Z,2026-01-28T14:21:03Z
192,731861,1,2026-01-28T14:12:35Z,2026-01-28T14:21:03Z

multiple jvms
Warehouses,Bops,Numb_JVMs,Start_Date,End_Date
24,988377,6,2026-01-28T14:21:43Z,2026-01-28T14:30:06Z
48,1686562,6,2026-01-28T14:21:43Z,2026-01-28T14:30:06Z
72,1683347,6,2026-01-28T14:21:43Z,2026-01-28T14:30:06Z
96,1491024,6,2026-01-28T14:21:43Z,2026-01-28T14:30:06Z
120,1485539,6,2026-01-28T14:21:43Z,2026-01-28T14:30:06Z
144,1364024,6,2026-01-28T14:21:43Z,2026-01-28T14:30:06Z
168,1330200,6,2026-01-28T14:21:43Z,2026-01-28T14:30:06Z
192,1302089,6,2026-01-28T14:21:43Z,2026-01-28T14:30:06Z




===============================
partial pcp output 
===============================
          o.w.iteration  o.w.running  o.w.numthreads  o.w.runtime  o.w.throughput  o.w.latency  o.w.JVMs  o.w.Warehouse  o.w.BOPs
14:21:08          0.000        0.000           0.000          NaN             NaN          NaN     1.000         48.000   1158553
14:21:09          0.000        0.000           0.000          NaN             NaN          NaN     1.000         48.000   1158553
14:21:12          0.000        0.000           0.000          NaN             NaN          NaN     1.000         72.000   1065174
14:21:13          0.000        0.000           0.000          NaN             NaN          NaN     1.000         72.000   1065174
14:21:17          0.000        0.000           0.000          NaN             NaN          NaN     1.000         96.000  961328.0
14:21:18          0.000        0.000           0.000          NaN             NaN          NaN     1.000         96.000  961328.0
14:21:21          0.000        0.000           0.000          NaN             NaN          NaN     1.000        120.000  918485.0
14:21:22          0.000        0.000           0.000          NaN             NaN          NaN     1.000        120.000  918485.0
14:21:25          0.000        0.000           0.000          NaN             NaN          NaN     1.000        144.000  872202.0
14:21:26          0.000        0.000           0.000          NaN             NaN          NaN     1.000        144.000  872202.0
14:21:29          0.000        0.000           0.000          NaN             NaN          NaN     1.000        168.000  808530.0
14:21:30          0.000        0.000           0.000          NaN             NaN          NaN     1.000        168.000  808530.0
14:21:33          0.000        0.000           0.000          NaN             NaN          NaN     1.000        192.000  731861.0
14:21:34          0.000        0.000           0.000          NaN             NaN          NaN     1.000        192.000  731861.0
14:30:03          0.000        1.000           0.000          NaN             NaN          NaN       NaN            NaN       NaN
14:30:04          0.000        1.000           0.000          NaN             NaN          NaN       NaN            NaN       NaN
14:30:05          0.000        1.000           0.000          NaN             NaN          NaN       NaN            NaN       NaN
14:30:06          0.000        1.000           0.000          NaN             NaN          NaN       NaN            NaN       NaN
14:30:07          0.000        1.000           0.000          NaN             NaN          NaN     6.000         24.000  988377.0
14:30:08          0.000        1.000           0.000          NaN             NaN          NaN     6.000         24.000  988377.0
14:30:12          0.000        0.000           0.000          NaN             NaN          NaN     6.000         48.000   1686562
14:30:13          0.000        0.000           0.000          NaN             NaN          NaN     6.000         48.000   1686562
14:30:16          0.000        0.000           0.000          NaN             NaN          NaN     6.000         72.000   1683347
14:30:17          0.000        0.000           0.000          NaN             NaN          NaN     6.000         72.000   1683347
14:30:20          0.000        0.000           0.000          NaN             NaN          NaN     6.000         96.000   1491024
14:30:21          0.000        0.000           0.000          NaN             NaN          NaN     6.000         96.000   1491024
14:30:25          0.000        0.000           0.000          NaN             NaN          NaN     6.000        120.000   1485539
14:30:26          0.000        0.000           0.000          NaN             NaN          NaN     6.000        120.000   1485539
14:30:29          0.000        0.000           0.000          NaN             NaN          NaN     6.000        144.000   1364024
14:30:30          0.000        0.000           0.000          NaN             NaN          NaN     6.000        144.000   1364024
14:30:34          0.000        0.000           0.000          NaN             NaN          NaN     6.000        168.000   1330200
14:30:37          0.000        0.000           0.000          NaN             NaN          NaN     6.000        192.000   1302089
14:30:38          0.000        0.000           0.000          NaN             NaN          NaN     6.000        192.000   1302089
~                                                                                                                                 



================================
Screen output from test
================================
[specjbb_out.txt](https://github.com/user-attachments/files/24913582/specjbb_out.txt)


