### PR TITLE
Need to return the rtc from verify

### DIFF
--- a/specjbb/specjbb_run
+++ b/specjbb/specjbb_run
@@ -79,7 +79,7 @@ if [ ! -f "/tmp/${test_name}.out" ]; then
 		cat /tmp/${test_name}.out
 		rm /tmp/${test_name}.out
 	fi
-	exit $?
+	exit $rtc
 fi
 
 #

--- a/specjbb/specjbb_run
+++ b/specjbb/specjbb_run
@@ -827,6 +827,7 @@ fi
 if [[ $rtc -eq 0 ]]; then
 	${TOOLS_BIN}/csv_to_json $to_json_flags --csv_file $save_csv_file --output_file results_specjbb.json
 	$TOOLS_BIN/verify_results $to_verify_flags --schema_file $script_dir/results_schema.py --class_name Specjbb_Results --file results_specjbb.json
+	rtc=$?
 	${TOOLS_BIN}/save_results --curdir $curdir --home_root $to_home_root --copy_dir /tmp/${RESULTSDIR_TOP} --test_name $test_name --tuned_setting=$to_tuned_setting --version NONE --user $to_user
 fi
 exit $rtc


### PR DESCRIPTION
# Description
We are not returning the rtc from the results verification

# Before/After Comparison
Before: we verified the data but did not return the rtc.
After: we verify the data and return the rtc.

# Clerical Stuff
This closes #52 

Relates to JIRA: RPOPC-831

Test Command executed
/home/ec2-user/workloads/specjbb-wrapper/specjbb/specjbb_run --run_user ec2-user --home_parent /home --iterations 1 --tuned_setting tuned_none_sys_file_ --host_config m5.xlarge --sysname m5.xlarge --sys_type aws --use_pcp --java_version 21

csv of successful run
Warehouses,Bops,Numb_JVMs,Start_Date,End_Date
2,109974,1,2026-02-06T10:35:03Z,2026-02-06T10:39:10Z
4,147291,1,2026-02-06T10:35:03Z,2026-02-06T10:39:10Z
6,139581,1,2026-02-06T10:35:03Z,2026-02-06T10:39:10Z
8,131452,1,2026-02-06T10:35:03Z,2026-02-06T10:39:10Z

rtc of successful run: 0

rtc of induced failure: 1
