### PR TITLE
Rerun

### DIFF
--- a/specjbb/specjbb_extra/run.sh
+++ b/specjbb/specjbb_extra/run.sh
@@ -5,6 +5,7 @@ stack_size=""
 jvm_of=1
 total_jvms=1
 
+source ${TOOLS_BIN}/error_codes
 NOARG_OPTS=(
 )
 
@@ -25,7 +26,7 @@ opts=$(getopt \
 
 if [ $? -ne 0 ]; then
 	echo No arguments
-        exit 1
+        exit $E_NO_ARGS
 fi
 
 eval set --$opts
@@ -52,7 +53,7 @@ while [[ $# -gt 0 ]]; do
                 ;;
                 *)
 			echo Unknown option $1
-			exit 1
+			exit $E_USAGE
 		;;
 	esac
 done
@@ -109,6 +110,6 @@ else
 	 xss_value="-Xss330k"
 fi
 
-$java -Xms${stack_size}m -Xmx${stack_size}m spec.jbb.JBBmain -propfile $PROPS_FILE
 date
+$java -Xms${stack_size}m -Xmx${stack_size}m spec.jbb.JBBmain -propfile $PROPS_FILE
 exit $?

--- a/specjbb/specjbb_run
+++ b/specjbb/specjbb_run
@@ -400,7 +400,7 @@ execute_specjbb()
 		controller_pid=$!
 		if [ "x$controller_pid" = "x" ]; then
 			printf "\t${benchmark}: unable to start the java controller\n\n"
-			exit 1
+			exit $E_GENERAL
 		fi
 		#
 		# Give it a chance to come up.
@@ -663,7 +663,7 @@ opts=$(getopt \
 # Verify there were no errors
 #
 if [ $? -ne 0 ]; then
-	error_out "Failed: parsing arguments." 1
+	error_out "Failed: parsing arguments." $E_PARSE_ARGS
 fi
 
 eval set --$opts
@@ -734,18 +734,21 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ ! -f ${run_dir}/specjbb.json ]]; then
-	error_out "Package definition file ${run_dir}/specjbb.json  is missing."
+	error_out "Package definition file ${run_dir}/specjbb.json is missing." $E_GENERAL
 fi
-${TOOLS_BIN}/package_tool --wrapper_config ${run_dir}/specjbb.json --no_packages $to_no_pkg_install
-if [[ $? -ne 0 ]]; then
-	error_out "Package installation of ${run_dir}/specjbb.json  using ${TOOLS_BIN}/package_tool was unsuccessful."
+package_tool --wrapper_config ${run_dir}/specjbb.json --no_packages $to_no_pkg_install
+prtc=$?
+if [[ $prtc -ne 0 ]]; then
+	error_out "Package installation of ${run_dir}/specjbb.json using ${TOOLS_BIN}/package_tool was unsuccessful." $prtc
 fi
 if [[ ! -f ${run_dir}/specjbb_${java_version}.json ]]; then
-	error_out "Package definition file ${run_dir}/specjbb_${java_version}.json  is missing.  Is the package file for $java_version defined?" 1
+	error_out "Package definition file ${run_dir}/specjbb_${java_version}.json is missing.  Is the package file for $java_version defined?" $E_GENERAL
 fi
-${TOOLS_BIN}/package_tool --wrapper_config ${run_dir}/specjbb_${java_version}.json --no_packages $to_no_pkg_install
-if [[ $? -ne 0 ]]; then
-	error_out "Package installation of ${run_dir}/specjbb_${java_version}.json  using ${TOOLS_BIN}/package_tool was unsuccessful."
+package_tool --wrapper_config ${run_dir}/specjbb_${java_version}.json --no_packages $to_no_pkg_install
+
+prtc=$?
+if [[ $prtc -ne 0 ]]; then
+	error_out "Package installation of ${run_dir}/specjbb_${java_version}.json using ${TOOLS_BIN}/package_tool was unsuccessful." $prtc
 fi
 
 #

--- a/specjbb/specjbb_run
+++ b/specjbb/specjbb_run
@@ -569,12 +569,44 @@ done
 #
 TOOLS_BIN=${HOME}/test_tools
 export TOOLS_BIN
-if [ ! -d "${TOOLS_BIN}" ]; then
-	git clone $tools_git ${TOOLS_BIN}
-	if [ $? -ne 0 ]; then
-		error_out "pulling git $tools_git failed." 1
-	fi
-fi
+
+attempt_tools_wget()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                wget ${tools_git}/archive/refs/heads/main.zip
+                if [[ $? -eq 0 ]]; then
+                        unzip -q main.zip
+                        mv test_tools-wrappers-main ${TOOLS_BIN}
+                        rm main.zip
+                fi
+        fi
+}
+
+attempt_tools_curl()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                curl -L -O ${tools_git}/archive/refs/heads/main.zip
+                if [[ $? -eq 0 ]]; then
+                        unzip -q main.zip
+                        mv test_tools-wrappers-main ${TOOLS_BIN}
+                        rm main.zip
+                fi
+        fi
+}
+
+attempt_tools_git()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                git clone $tools_git "$TOOLS_BIN"
+                if [ $? -ne 0 ]; then
+                        exit_out "Error: pulling git $tools_git failed." 101
+                fi
+        fi
+}
+
+attempt_tools_wget
+attempt_tools_curl
+attempt_tools_git
 
 if [ $show_usage -eq 1 ]; then
 	usage $0


### PR DESCRIPTION
# Description
Uses error_codes found in test_tools/error_codes to provide more specific error indication.

# Before/After Comparison

Before: Returned a 0 or 1, making determination of having to rerun very course
After: Error codes are now bases on test_tools/error_codes, making it easier to limit when we do a rerun of the test.
Also, changed how we load in test_tools, we try curl, git, and wget, to avoid a failure due to the program not
being installed.

# Clerical Stuff
This closes #54 

Relates to JIRA: RPOPC-876

Testing

Ran following scenario
global:
  ssh_key_file: replace_your_ssh_key
  terminate_cloud: 1
  os_vendor: rhel
  results_prefix: documentation
  os_vendor: rhel
  system_type: aws
  cloud_os_id: ami-035032ea878eca201
systems:
  system1:
    tests: "specjbb"
    java_version: java-21
    host_config: "m5.xlarge"

csv file
Warehouses,Bops,Numb_JVMs,Start_Date,End_Date
2,126995,1,2026-03-13T19:19:21Z,2026-03-13T19:23:27Z
4,173595,1,2026-03-13T19:19:21Z,2026-03-13T19:23:27Z
6,170373,1,2026-03-13T19:19:21Z,2026-03-13T19:23:27Z
8,165038,1,2026-03-13T19:19:21Z,2026-03-13T19:23:27Z

Returned 0 as expected. Testing on rerun verification handled in the appropriate zathras pr.